### PR TITLE
Add function to determine attribute write only access

### DIFF
--- a/deconz/zcl.h
+++ b/deconz/zcl.h
@@ -768,6 +768,8 @@ Shorthand for creating type safe manufacturer codes from numbers but without cas
         int64_t lastRead() const;
         /*! Returns true if the attribute is read only. */
         bool isReadonly() const;
+        /*! Returns true if the attribute is write only. */
+        bool isWriteonly() const;
         /*! Returns true if the attribute is mandatory. */
         bool isMandatory() const;
         /*! Returns true if the attribute is available on the device. */

--- a/zcl.cpp
+++ b/zcl.cpp
@@ -1602,6 +1602,12 @@ bool ZclAttribute::isReadonly() const
     return (d->m_access == ZclRead);
 }
 
+bool ZclAttribute::isWriteonly() const
+{
+    Q_D(const ZclAttribute);
+    return (d->m_access == ZclWrite);
+}
+
 bool ZclAttribute::isMandatory() const
 {
     Q_D(const ZclAttribute);


### PR DESCRIPTION
Determins if access for an attribute is write only - prerequisite to display access in the GUI correctly.

**Required for https://github.com/dresden-elektronik/deconz/pull/12**