### PR TITLE
add missing declspec.h to PUB_INCLUDE_FILES

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ set(PUB_INCLUDE_FILES
     deconz/node_interface.h
     deconz/http_client_handler.h
     deconz/qhttprequest_compat.h
+    deconz/declspec.h
 )
 
 add_library(${PROJECT_NAME} SHARED


### PR DESCRIPTION
deconz.h has deconz/declspec.h as [include](https://github.com/dresden-elektronik/deconz-lib/blob/6ed16b945c500ee2f2de206f21a52e4ab6e8f7eb/deconz.h#L19) but the file is not included in the PUB_INCLUDE_FILES.
This leads to build fails of plugins which have to include deconz.h.

Occures when using `cmake --install build` to install the libraries or using other methods of out-of-tree building.